### PR TITLE
Make it safer. faster and provide better visitors privacy

### DIFF
--- a/conf/nginx/prod.openbroadcast.org.nginx.conf
+++ b/conf/nginx/prod.openbroadcast.org.nginx.conf
@@ -11,8 +11,8 @@ server {
     listen 95.211.179.43:80;
     server_name prod.openbroadcast.org;
     server_tokens off;
-    access_log  /var/log/nginx/openbroadcast.org_nonssl;
-    rewrite ^/(.*) https://prod.openbroadcast.org/$1 permanent;
+    #access_log  /var/log/nginx/openbroadcast.org_nonssl;
+    return 301 https://$server_name$request_uri;
 }
 
 server {
@@ -22,6 +22,27 @@ server {
 
     ssl_certificate      /root/keys/ssl/prod.openbroadcast.org/server.crt;
     ssl_certificate_key  /root/keys/ssl/prod.openbroadcast.org/server.key;
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:50m;
+
+    # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
+    #ssl_dhparam /etc/ssl/dh_2048.pem;
+
+    # intermediate configuration. tweak to your needs.
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA';
+    ssl_prefer_server_ciphers on;
+
+    # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
+    add_header Strict-Transport-Security max-age=15768000;
+
+    # OCSP Stapling ---
+    # fetch OCSP records from URL in ssl_certificate and cache them
+    #ssl_stapling on;
+    #ssl_stapling_verify on;
+
+    ## verify chain of trust of OCSP response using Root CA and Intermediate certs
+    #ssl_trusted_certificate /etc/ssl/gd-g2.ocsp-chain.pem;
 
     #access_log  /var/log/nginx/prod.openbroadcast.org;
 


### PR DESCRIPTION
The proposed changes where generated with 
https://mozilla.github.io/server-side-tls/ssl-config-generator/.

 * The changes will make faster connections, as they prefer 128bit handshakes over 256bit.
 * The server will almost exclusively use cipher suites which provide perfect forward secrecy (PFS).
    Strict-Transport-Security (HSTS) will advise browsers not to attempt unencrypted connections
    (only to get fowarded later)
 * OCSP-Stapling will no longer require client connections to the CA during handshakes to verify
   certificate (faster, less 3rd-party user tracking).
 * Protect against logjam attacks with your own set of Diffie-Hellman key exchange parameters
   (needs to be created)
 * Just forward unencrypted connections as is, no need for expensive regex and rewirte processing.
 * Consider skipping useless logging of unencrpyted forwards.

Check and compare results before and after: https://www.ssllabs.com/ssltest/analyze.html?d=openbroadcast.org

To create DH parameters:

	$ sudo openssl dhparam -out /etc/ssl/dh_2048.pem 2048
	$ sudo chmod 644 /etc/ssl/dh_2048.pem

To create the OCSP chain file:

	$ wget http://certificates.godaddy.com/repository/gdig2.crt
	$ wget https://certs.godaddy.com/repository/gdroot-g2.crt
	$ cat gdroot-g2.crt gdig2.crt > gd-g2.ocsp-chain.pem
	$ sudo cp gd-g2.ocsp-chain.pem /etc/ssl/gd-g2.ocsp-chain.pem